### PR TITLE
絶対パスの取得方法の変更

### DIFF
--- a/src/main/kotlin/io/github/t45k/clione/controller/NiCadController.kt
+++ b/src/main/kotlin/io/github/t45k/clione/controller/NiCadController.kt
@@ -69,7 +69,7 @@ class NiCadController(private val sourceCodePath: Path, private val config: Runn
     }
 
     private fun execute() {
-        val command: Array<String> = arrayOf("./nicad6", "blocks", config.lang, sourceCodePath.toAbsolutePath().toString(), "clione")
+        val command: Array<String> = arrayOf("./nicad6", "blocks", config.lang, sourceCodePath.toRealPath().toString(), "clione")
         val result: CommandLine.CommandLineResult = CommandLine().execute(nicadDir.toFile(), *command)
         if (!result.isSuccess) {
             throw RuntimeException(result.outputLines.joinToString("\n"))

--- a/src/main/kotlin/util/FileUtil.kt
+++ b/src/main/kotlin/util/FileUtil.kt
@@ -12,3 +12,4 @@ fun deleteRecursive(path: Path) {
 }
 
 fun String.toPath(): Path = Path.of(this)
+fun String.toRealPath(): Path = Path.of(this).toRealPath()

--- a/src/test/kotlin/io/github/t45k/clione/core/CloneTrackerTest.kt
+++ b/src/test/kotlin/io/github/t45k/clione/core/CloneTrackerTest.kt
@@ -7,7 +7,7 @@ import io.github.t45k.clione.entity.CloneStatus
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Test
-import util.toPath
+import util.toRealPath
 import kotlin.test.assertEquals
 
 internal class CloneTrackerTest {
@@ -33,12 +33,12 @@ internal class CloneTrackerTest {
         val newFileCache: MutableMap<String, List<String>> = mutableMapOf()
         val (_, newIdCloneMap) = cloneDetector.collectResult(changedFile, CloneStatus.ADD, newFileCache)
         cloneDetector.parseCandidateXML(newFileCache, changedFile).forEach { candidate -> newIdCloneMap.computeIfAbsent(candidate.id) { candidate } }
-        val newFileClonesMap = newIdCloneMap.values.groupBy { it.fileName.substringAfter("./").toPath().toAbsolutePath().toString() }
+        val newFileClonesMap = newIdCloneMap.values.groupBy { it.fileName.toRealPath().toString() }
 
         git.checkout(OLD_COMMIT_HASH)
         val oldFileCache: MutableMap<String, List<String>> = mutableMapOf()
         val (oldCloneSets, oldIdCloneMap) = cloneDetector.collectResult(changedFile, CloneStatus.DELETE, oldFileCache)
-        val oldFileClonesMap = oldIdCloneMap.values.groupBy { it.fileName.substringAfter("./").toPath().toAbsolutePath().toString() }
+        val oldFileClonesMap = oldIdCloneMap.values.groupBy { it.fileName.toRealPath().toString() }
 
         val cloneTracker = CloneTracker(git, pullRequest, config)
         cloneTracker.mapClones(oldFileClonesMap, newFileClonesMap, changedFile, OLD_COMMIT_HASH, NEW_COMMIT_HASH)


### PR DESCRIPTION
`Path#toAbsolutePath` -> `Path#toRealPath`

realpathだと`./hoge/../`みたいなのが最適化される