### PR TITLE
小さな修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ out/
 
 ./src/main/resources/github.properties
 ./src/main/resources/verify.properties
+
+./storage/*

--- a/src/main/kotlin/io/github/t45k/clione/controller/cloneDetector/NiCadController.kt
+++ b/src/main/kotlin/io/github/t45k/clione/controller/cloneDetector/NiCadController.kt
@@ -11,7 +11,7 @@ import io.github.t45k.clione.entity.IdCloneMap
 import io.github.t45k.clione.entity.NoPropertyFileExistsException
 import io.github.t45k.clione.util.deleteRecursive
 import io.github.t45k.clione.util.toPath
-import org.jgrapht.alg.clique.BronKerboschCliqueFinder
+import org.jgrapht.alg.clique.DegeneracyBronKerboschCliqueFinder
 import org.jgrapht.graph.DefaultEdge
 import org.jgrapht.graph.SimpleGraph
 import org.slf4j.Logger
@@ -111,7 +111,7 @@ class NiCadController(private val sourceCodePath: Path, private val config: Runn
                     cloneRelationGraph to idCloneMap
                 })
             .let {
-                BronKerboschCliqueFinder(it.first)
+                DegeneracyBronKerboschCliqueFinder(it.first)
                     .iterator()
                     .asSequence()
                     .toList() to it.second

--- a/src/main/kotlin/io/github/t45k/clione/controller/cloneDetector/sourcerercc/SourcererCCController.kt
+++ b/src/main/kotlin/io/github/t45k/clione/controller/cloneDetector/sourcerercc/SourcererCCController.kt
@@ -9,7 +9,7 @@ import io.github.t45k.clione.entity.CloneSets
 import io.github.t45k.clione.entity.CloneStatus
 import io.github.t45k.clione.entity.IdCloneMap
 import io.github.t45k.clione.util.deleteRecursive
-import org.jgrapht.alg.clique.BronKerboschCliqueFinder
+import org.jgrapht.alg.clique.DegeneracyBronKerboschCliqueFinder
 import org.jgrapht.graph.DefaultEdge
 import org.jgrapht.graph.SimpleGraph
 import org.slf4j.Logger
@@ -111,7 +111,7 @@ class SourcererCCController(private val sourceCodePath: Path, private val config
                 graph
             }
             .let {
-                BronKerboschCliqueFinder(it)
+                DegeneracyBronKerboschCliqueFinder(it)
                     .iterator()
                     .asSequence()
                     .toList()

--- a/src/main/kotlin/io/github/t45k/clione/core/CloneTracker.kt
+++ b/src/main/kotlin/io/github/t45k/clione/core/CloneTracker.kt
@@ -37,9 +37,9 @@ class CloneTracker(private val git: GitController, private val pullRequest: Pull
         git.checkout(newCommitHash)
         val (newCloneSets: CloneSets, newIdCloneMap: IdCloneMap) = cloneDetector.execute(newChangedFiles, CloneStatus.ADD)
         val newFileClonesMap: FileClonesMap = newIdCloneMap.values.groupBy { it.fileName }
-        logger.info("[START]\tNew revision: $newCommitHash")
+        logger.info("[END]\tNew revision: $newCommitHash")
 
-        logger.info("[END]\tOld revision: $oldCommitHash")
+        logger.info("[START]\tOld revision: $oldCommitHash")
         git.checkout(oldCommitHash)
         val (oldCloneSets: CloneSets, oldIdCloneMap: IdCloneMap) = cloneDetector.execute(oldChangedFiles, CloneStatus.DELETE)
         val oldFileClonesMap: FileClonesMap = oldIdCloneMap.values.groupBy { it.fileName }

--- a/src/main/resources/sourcerer-cc.properties
+++ b/src/main/resources/sourcerer-cc.properties
@@ -8,7 +8,7 @@ IS_STATUS_REPORTER_ON=true
 #for recovery
 LOG_PROCESSED_LINENUMBER_AFTER_X_LINES=50
 # Ignore all files outside these bounds
-MIN_TOKENS=30
+MIN_TOKENS=10
 MAX_TOKENS=500000
 # Sharding speeds up search for very large datasets (>200K files).
 # For small-ish datasets, it doesn't matter so much

--- a/src/main/resources/sourcerer-cc.properties
+++ b/src/main/resources/sourcerer-cc.properties
@@ -8,7 +8,7 @@ IS_STATUS_REPORTER_ON=true
 #for recovery
 LOG_PROCESSED_LINENUMBER_AFTER_X_LINES=50
 # Ignore all files outside these bounds
-MIN_TOKENS=10
+MIN_TOKENS=30
 MAX_TOKENS=500000
 # Sharding speeds up search for very large datasets (>200K files).
 # For small-ish datasets, it doesn't matter so much


### PR DESCRIPTION
- `./storage`ディレクトリを保持
- 極大クリーク検出アルゴリズムを[既存ツール](https://github.com/s-tokui/CloneNotifier/blob/master/CloneNotifier/src/cn/analyze/SourcererccController.java#L325)と同一のものに変更
- ~~SCCの最小トークン数を30に変更~~ 実験の都合上10でいく
- loggerの出力内容を修正