### PR TITLE
設定ファイルを読み込む前に先頭コミットにチェックアウトするように変更

### DIFF
--- a/src/main/kotlin/io/github/t45k/clione/controller/ClioneApiController.kt
+++ b/src/main/kotlin/io/github/t45k/clione/controller/ClioneApiController.kt
@@ -70,6 +70,7 @@ class ClioneApiController {
 
         try {
             GitController.cloneIfNotExists(repositoryFullName, token, pullRequest).use { git ->
+                git.checkout(pullRequest.headCommitHash)
                 val config: RunningConfig = if (Files.exists(git.getProjectPath().resolve(CONFIGURATION_LOCATION))) {
                     git.getProjectPath().resolve(CONFIGURATION_LOCATION)
                         .let(Files::readString)


### PR DESCRIPTION
どっかのタイミングでgit-clone時にチェックアウトしないように変更したので，その代わり設定ファイルを読む際にチェックアウトするように変更